### PR TITLE
Feature/code lens

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
 				"id": "clover.helper",
 				"label": "Clover",
 					"icon": {
-					"dark": "resources/dark/clover.svg",
-					"light": "resources/light/clover.svg"
+						"dark": "resources/dark/clover.svg",
+						"light": "resources/light/clover.svg"
 				}
 			}
 		]

--- a/src/codelensProvider.ts
+++ b/src/codelensProvider.ts
@@ -1,0 +1,54 @@
+import * as vscode from 'vscode';
+
+/**
+ * CodelensProvider
+ */
+export class CodelensProvider implements vscode.CodeLensProvider {
+
+	private codeLenses: vscode.CodeLens[] = [];
+	private regex: RegExp;
+	private _onDidChangeCodeLenses: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
+	public readonly onDidChangeCodeLenses: vscode.Event<void> = this._onDidChangeCodeLenses.event;
+
+	constructor() {
+		this.regex = /(.+)/g;
+
+		vscode.workspace.onDidChangeConfiguration((_) => {
+			this._onDidChangeCodeLenses.fire();
+		});
+	}
+
+	public provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
+
+		if (vscode.workspace.getConfiguration("codelens-sample").get("enableCodeLens", true)) {
+			this.codeLenses = [];
+			const regex = new RegExp(this.regex);
+			const text = document.getText();
+			let matches;
+			while ((matches = regex.exec(text)) !== null) {
+				const line = document.lineAt(document.positionAt(matches.index).line);
+				const indexOf = line.text.indexOf(matches[0]);
+				const position = new vscode.Position(line.lineNumber, indexOf);
+				const range = document.getWordRangeAtPosition(position, new RegExp(this.regex));
+				if (range) {
+					this.codeLenses.push(new vscode.CodeLens(range));
+				}
+			}
+			return this.codeLenses;
+		}
+		return [];
+	}
+
+	public resolveCodeLens(codeLens: vscode.CodeLens, token: vscode.CancellationToken) {
+		if (vscode.workspace.getConfiguration("codelens-sample").get("enableCodeLens", true)) {
+			codeLens.command = {
+				title: "Codelens provided by sample extension",
+				tooltip: "Tooltip provided by sample extension",
+				command: "codelens-sample.codelensAction",
+				arguments: ["Argument 1", false]
+			};
+			return codeLens;
+		}
+		return null;
+	}
+}

--- a/src/codelensProvider.ts
+++ b/src/codelensProvider.ts
@@ -33,7 +33,7 @@ export class CodelensProvider implements vscode.CodeLensProvider {
 	public resolveCodeLens(codeLens: vscode.CodeLens, token: vscode.CancellationToken) {
 		codeLens.command = {
 			title: "meta references",
-			command: "clover.unity.codeLensAction",
+			command: "clover.findFileReference",
 			arguments: ["Argument 1", false]
 		};
 		return codeLens;

--- a/src/codelensProvider.ts
+++ b/src/codelensProvider.ts
@@ -20,9 +20,6 @@ export class CodelensProvider implements vscode.CodeLensProvider {
 
 	public provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
 			this.codeLenses = [];
-			outputLog("beefore prase");
-			outputLog(path.parse(document.uri.fsPath).name);
-			outputLog("WHy");
 			const regex = new RegExp(`class ${path.parse(document.uri.fsPath).name}`);
 			const text = document.getText();
 			let matches;

--- a/src/codelensProvider.ts
+++ b/src/codelensProvider.ts
@@ -1,54 +1,44 @@
 import * as vscode from 'vscode';
+import path = require("path");
+import { outputLog } from './logger';
 
-/**
- * CodelensProvider
- */
 export class CodelensProvider implements vscode.CodeLensProvider {
 
 	private codeLenses: vscode.CodeLens[] = [];
-	private regex: RegExp;
 	private _onDidChangeCodeLenses: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
 	public readonly onDidChangeCodeLenses: vscode.Event<void> = this._onDidChangeCodeLenses.event;
 
 	constructor() {
-		this.regex = /(.+)/g;
-
+		let file = vscode.window.activeTextEditor?.document.uri.fsPath;
+		
 		vscode.workspace.onDidChangeConfiguration((_) => {
 			this._onDidChangeCodeLenses.fire();
 		});
+
+		outputLog("Initialize succeed CodeLens Provider");
 	}
 
 	public provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
-
-		if (vscode.workspace.getConfiguration("codelens-sample").get("enableCodeLens", true)) {
 			this.codeLenses = [];
-			const regex = new RegExp(this.regex);
+			outputLog("beefore prase");
+			outputLog(path.parse(document.uri.fsPath).name);
+			outputLog("WHy");
+			const regex = new RegExp(`class ${path.parse(document.uri.fsPath).name}`);
 			const text = document.getText();
 			let matches;
-			while ((matches = regex.exec(text)) !== null) {
+			if ((matches = regex.exec(text)) !== null) {
 				const line = document.lineAt(document.positionAt(matches.index).line);
-				const indexOf = line.text.indexOf(matches[0]);
-				const position = new vscode.Position(line.lineNumber, indexOf);
-				const range = document.getWordRangeAtPosition(position, new RegExp(this.regex));
-				if (range) {
-					this.codeLenses.push(new vscode.CodeLens(range));
-				}
+				this.codeLenses.push(new vscode.CodeLens(line.range));
 			}
 			return this.codeLenses;
-		}
-		return [];
 	}
 
 	public resolveCodeLens(codeLens: vscode.CodeLens, token: vscode.CancellationToken) {
-		if (vscode.workspace.getConfiguration("codelens-sample").get("enableCodeLens", true)) {
-			codeLens.command = {
-				title: "Codelens provided by sample extension",
-				tooltip: "Tooltip provided by sample extension",
-				command: "codelens-sample.codelensAction",
-				arguments: ["Argument 1", false]
-			};
-			return codeLens;
-		}
-		return null;
+		codeLens.command = {
+			title: "meta references",
+			command: "clover.unity.codeLensAction",
+			arguments: ["Argument 1", false]
+		};
+		return codeLens;
 	}
 }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -4,6 +4,7 @@ import path = require("path");
 import { outputLog } from './logger';
 import { getGuid } from './parser';
 import { updateStatus } from './vscode/command';
+import { CodelensProvider } from './codelensProvider';
 
 let files: string[];
 let assetPath: string;
@@ -12,12 +13,16 @@ export function initialize() {
     let workspace = vscode.workspace.workspaceFolders;
 
     if (workspace !== undefined) {
-        assetPath = workspace[0].uri.fsPath + path.sep +'Assets';
+        assetPath = path.join(workspace[0].uri.fsPath, 'Assets');
         updateStatus<boolean>('clover.workspace.valid', fs.lstatSync(assetPath).isDirectory());
 
         syncUnityFiles();
         updateStatus<boolean>('clover.unity.initialized', true);
     }
+
+    const codelensProvider = new CodelensProvider();
+
+	vscode.languages.registerCodeLensProvider("csharp", codelensProvider);
 }
 
 export function syncUnityFiles() {

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -21,6 +21,9 @@ export function initialize() {
     }
 
     const codelensProvider = new CodelensProvider();
+    vscode.commands.registerCommand("clover.unity.codeLensAction", (args: any) => {
+		vscode.window.showInformationMessage(`CodeLens action clicked with args=${args}`);
+	});
 
 	vscode.languages.registerCodeLensProvider("csharp", codelensProvider);
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -4,4 +4,5 @@ let clover = vscode.window.createOutputChannel("Clover");
 
 export function outputLog(log: string) {
     clover.appendLine(`[${new Date().toLocaleTimeString()}] ${log}`);
+    clover.show();
 }


### PR DESCRIPTION
Added
- code lens feature
![image](https://user-images.githubusercontent.com/37071240/210164892-962e1a34-fbba-4b96-bc72-60e7c41fe02f.png)

That feature position is focus on RegExp for current editor focus file class name. Maybe will be change this position find more good logic.

Changed
- Now output channel show when message displayed