### PR TITLE
Feature/improve code lens

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,12 @@
         "category": "Clover",
         "title": "Refresh Unity Project",
         "enablement": "clover.workspace.valid"
+      },
+      {
+        "command": "clover.test",
+        "category": "Clover",
+        "title": "test",
+        "enablement": "clover.workspace.valid"
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -61,12 +61,6 @@
         "category": "Clover",
         "title": "Refresh Unity Project",
         "enablement": "clover.workspace.valid"
-      },
-      {
-        "command": "clover.test",
-        "category": "Clover",
-        "title": "test",
-        "enablement": "clover.workspace.valid"
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -51,10 +51,10 @@
     },
     "commands": [
       {
-        "command": "clover.findFileReference",
+        "command": "clover.findMetaReference",
         "category": "Clover",
         "enablement": "resourceExtname == .cs || resourceExtname == .asset",
-        "title": "Find Prefab Reference"
+        "title": "Find Meta Reference"
       },
       {
         "command": "clover.refreshUnityProject",
@@ -79,7 +79,7 @@
       ],
       "clover.helper": [
         {
-          "command": "clover.findFileReference"
+          "command": "clover.findMetaReference"
         },
         {
           "command": "clover.refreshUnityProject"

--- a/src/codelensProvider.ts
+++ b/src/codelensProvider.ts
@@ -49,7 +49,7 @@ export class CodelensProvider implements vscode.CodeLensProvider {
 
 		codeLens.command = {
 			title: this.getTitle(metaData),
-			command: "editor.action.showReferences",
+			command: metaData.length == 0 ? "clover.noReferenceMessage" : "editor.action.showReferences",
 			arguments: [codeLens.document, new vscode.Position(0, 0), [new vscode.Location(codeLens.document, new vscode.Position(0, 0)), new vscode.Location(codeLens.document, new vscode.Position(1, 0))]],
 		};
 		return codeLens;

--- a/src/codelensProvider.ts
+++ b/src/codelensProvider.ts
@@ -2,6 +2,16 @@ import * as vscode from 'vscode';
 import path = require("path");
 import { outputLog } from './logger';
 
+export class AssetUsageCodeLens extends vscode.CodeLens {
+	constructor(
+		public document: vscode.Uri,
+		public file: string,
+		range: vscode.Range
+	) {
+		super(range);
+	}
+}
+
 export class CodelensProvider implements vscode.CodeLensProvider {
 
 	private codeLenses: vscode.CodeLens[] = [];
@@ -27,14 +37,14 @@ export class CodelensProvider implements vscode.CodeLensProvider {
 				const line = document.lineAt(document.positionAt(matches.index).line);
 				this.codeLenses.push(new vscode.CodeLens(line.range));
 			}
-			return this.codeLenses;
+			return this.codeLenses.map((codeLens) => new AssetUsageCodeLens(document.uri, document.uri.fsPath, codeLens.range));
 	}
 
-	public resolveCodeLens(codeLens: vscode.CodeLens, token: vscode.CancellationToken) {
+	public resolveCodeLens(codeLens: AssetUsageCodeLens, token: vscode.CancellationToken) {
 		codeLens.command = {
 			title: "meta references",
-			command: "clover.findFileReference",
-			arguments: ["Argument 1", false]
+			command: "editor.action.showReferences",
+			arguments: [codeLens.document, new vscode.Position(0, 0), [new vscode.Location(codeLens.document, new vscode.Position(0, 0)), new vscode.Location(codeLens.document, new vscode.Position(1, 0))]]
 		};
 		return codeLens;
 	}

--- a/src/codelensProvider.ts
+++ b/src/codelensProvider.ts
@@ -9,7 +9,6 @@ class MetaReferenceCodeLens extends vscode.CodeLens {
 	constructor(
 		public document: vscode.Uri,
 		public file: string,
-		public line: number,
 		range: vscode.Range
 	) {
 		super(range);
@@ -39,9 +38,8 @@ export class CodelensProvider implements vscode.CodeLensProvider {
 			const text = document.getText();
 			let matches;
 			if ((matches = regex.exec(text)) !== null) {
-				const lineNumber = document.positionAt(matches.index).line;
-				const line = document.lineAt(lineNumber);
-				this.codeLenses.push(new MetaReferenceCodeLens(document.uri, document.uri.fsPath, lineNumber, line.range));
+				const line = document.lineAt(document.positionAt(matches.index).line);
+				this.codeLenses.push(new MetaReferenceCodeLens(document.uri, document.uri.fsPath,line.range));
 			}
 			return this.codeLenses;
 	}
@@ -55,7 +53,7 @@ export class CodelensProvider implements vscode.CodeLensProvider {
 		codeLens.command = {
 			title: this.getTitle(metaDatas),
 			command: metaDatas.length == 0 ? "clover.noReferenceMessage" : "editor.action.showReferences",
-			arguments: [codeLens.document, new vscode.Position(codeLens.line, 0), locations],
+			arguments: [codeLens.document, codeLens.range.start, locations],
 		};
 		return codeLens;
 	}

--- a/src/codelensProvider.ts
+++ b/src/codelensProvider.ts
@@ -48,7 +48,7 @@ export class CodelensProvider implements vscode.CodeLensProvider {
 		var guid = parser.getGuid(`${codeLens.document.fsPath}.meta`);
 		var metaDatas = loader.getMetaData(guid);
 
-		var locations = this.getLocations(metaDatas);
+		var locations = this.getLocations(guid, metaDatas);
 
 		codeLens.command = {
 			title: this.getTitle(metaDatas),
@@ -66,15 +66,15 @@ export class CodelensProvider implements vscode.CodeLensProvider {
 		}
 	}
 
-	getLocations(metaDatas: MetaData[]): vscode.Location[] {
-		return metaDatas.map(CodelensProvider.metaDataToLocation);
-	}
-
-	static metaDataToLocation(metaData: MetaData): vscode.Location {
-		console.log(metaData.path);
-		const uri = vscode.Uri.parse(metaData.path);
-		console.log(uri.toString());
-		const position = new vscode.Position(0, 0); // 예시로 첫 번째 줄의 첫 번째 열을 사용
-		return new vscode.Location(uri, position);
+	getLocations(guid: string, metaDatas: MetaData[]): vscode.Location[] {
+		let locations: vscode.Location[] = [];
+		metaDatas.forEach((metaData) => {
+			const lineNUmbers = parser.getLineNumbers(guid, metaData.path);
+			const uri = vscode.Uri.parse(metaData.path);
+			lineNUmbers.forEach((lineNumber) => {
+				locations.push(new vscode.Location(uri, new vscode.Position(lineNumber, 0)));
+			});
+		});
+		return locations;
 	}
 }

--- a/src/codelensProvider.ts
+++ b/src/codelensProvider.ts
@@ -9,6 +9,7 @@ class MetaReferenceCodeLens extends vscode.CodeLens {
 	constructor(
 		public document: vscode.Uri,
 		public file: string,
+		public line: number,
 		range: vscode.Range
 	) {
 		super(range);
@@ -38,8 +39,9 @@ export class CodelensProvider implements vscode.CodeLensProvider {
 			const text = document.getText();
 			let matches;
 			if ((matches = regex.exec(text)) !== null) {
-				const line = document.lineAt(document.positionAt(matches.index).line);
-				this.codeLenses.push(new MetaReferenceCodeLens(document.uri, document.uri.fsPath, line.range));
+				const lineNumber = document.positionAt(matches.index).line;
+				const line = document.lineAt(lineNumber);
+				this.codeLenses.push(new MetaReferenceCodeLens(document.uri, document.uri.fsPath, lineNumber, line.range));
 			}
 			return this.codeLenses;
 	}
@@ -53,7 +55,7 @@ export class CodelensProvider implements vscode.CodeLensProvider {
 		codeLens.command = {
 			title: this.getTitle(metaDatas),
 			command: metaDatas.length == 0 ? "clover.noReferenceMessage" : "editor.action.showReferences",
-			arguments: [codeLens.document, new vscode.Position(0, 0), locations],
+			arguments: [codeLens.document, new vscode.Position(codeLens.line, 0), locations],
 		};
 		return codeLens;
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,4 +7,60 @@ export function activate(context: vscode.ExtensionContext) {
 	new MetaExplorer(context);
 	initialize(context);
     vscode.commands.executeCommand('workbench.view.extension.clover-activitybar');
+    var simple = new SimpleReferenceProvider();
+    context.subscriptions.push(vscode.languages.registerReferenceProvider({ language: 'csharp' }, simple));
+    context.subscriptions.push(vscode.commands.registerCommand('clover.test', () => {
+        console.log('test')
+        if (vscode.window.activeTextEditor) {
+            console.log('test2');
+            var locations = [ new vscode.Location(vscode.window.activeTextEditor.document.uri, new vscode.Position(1, 0)), new vscode.Location(vscode.window.activeTextEditor.document.uri, new vscode.Position(2, 0)) ];
+            vscode.commands.executeCommand('editor.action.showReferences', vscode.window.activeTextEditor.document.uri, new vscode.Position(0, 0), locations);
+        }
+    }));
+}
+
+class test implements vscode.ReferenceContext {
+    includeDeclaration: boolean;
+    /**
+     *
+     */
+    constructor() {
+        this.includeDeclaration = true;
+    }
+}
+
+class test2 implements vscode.CancellationToken {
+    isCancellationRequested: boolean;
+    onCancellationRequested: vscode.Event<any>;
+    constructor() {
+        this.isCancellationRequested = false;
+        this.onCancellationRequested = new vscode.EventEmitter().event;
+    }
+}
+
+class SimpleReferenceProvider implements vscode.ReferenceProvider {
+    provideReferences(document: vscode.TextDocument, position: vscode.Position, context: vscode.ReferenceContext, token: vscode.CancellationToken): vscode.ProviderResult<vscode.Location[]> {
+        console.log('test3')
+
+        // Get selected word or symbol
+        const wordRange = document.getWordRangeAtPosition(position);
+        const selectedWord = wordRange ? document.getText(wordRange) : '';
+
+        // Find references
+        const references: vscode.Location[] = [];
+
+        // for (let i = 0; i < document.lineCount; i++) {
+        //     const line = document.lineAt(i);
+        //     const index = line.text.indexOf(selectedWord);
+        //     if (index !== -1) {
+        //         const referenceLocation = new vscode.Location(document.uri, new vscode.Range(new vscode.Position(i, index), new vscode.Position(i, index + selectedWord.length)));
+        //         references.push(referenceLocation);
+        //     }
+        // }
+        references.push(new vscode.Location(document.uri, new vscode.Position(0, 0)));
+        references.push(new vscode.Location(document.uri, new vscode.Position(1, 1)));
+        console.log('test4')
+
+        return references;
+    }
 }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -68,14 +68,11 @@ export function findMetaReference() {
   const guid = getGuid(metaFilePath);
 
   outputLog(`${path.basename(currentFilePath)} reference list`);
-
-  files.forEach(prefab => {
-    const prefabContent = fs.readFileSync(prefab, { encoding: 'utf8' });
-    if (prefabContent.includes(guid)) {
-      const relativePath = path.relative(currentFolder, prefab);
-      metaExplorer.addItem(relativePath);
-      outputLog(relativePath);
-    }
+  const metaDatas = getMetaData(guid);
+  metaDatas.forEach((metaData) => {
+    const relativePath = path.relative(currentFolder, metaData.path);
+    metaExplorer.addItem(relativePath);
+    outputLog(metaData.path);
   });
 }
 

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -12,7 +12,6 @@ import { MetaData } from './metaData';
 let files: string[];
 let assetPath: string;
 let metaExplorer: MetaExplorer;
-
 var metaDatas: Map<string, MetaData[]> = new Map<string, MetaData[]>();
 
 export async function initialize(context: vscode.ExtensionContext) {
@@ -67,8 +66,7 @@ export function findMetaReference() {
     return;
   }
 
-  const metaFileContent = fs.readFileSync(metaFilePath, { encoding: 'utf8' });
-  const guid = getGuid(metaFileContent);
+  const guid = getGuid(metaFilePath);
 
   outputLog(`${path.basename(currentFilePath)} reference list`);
 
@@ -123,4 +121,8 @@ function addMetaData(guid: string, path: string) {
   } else {
     metaDatas.set(guid, [new MetaData(path)]);
   }
+}
+
+export function getMetaData(guid: string) {
+  return metaDatas.get(guid) ?? [];
 }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -43,7 +43,7 @@ export async function initialize(context: vscode.ExtensionContext) {
 export async function refreshUnityProject() {
   vscode.window.showInformationMessage('Start Refresh Unity Project');
   outputLog('Start Refresh Unity Project');
-  await sync(assetPath);
+  await refresh(assetPath);
   console.log(metaDatas);
   vscode.window.showInformationMessage('Finish Refresh Unity Project');
   outputLog('Finish Refresh Unity Project');
@@ -82,7 +82,7 @@ export function findMetaReference() {
   });
 }
 
-function sync(dirPath: string): Promise<void> {
+function refresh(dirPath: string): Promise<void> {
   return new Promise((resolve, reject) => {
     fs.readdir(dirPath, (err, files) => {
       if (err) {
@@ -92,7 +92,7 @@ function sync(dirPath: string): Promise<void> {
           for (const file of files) {
             const extname = path.extname(file);
             if (fs.statSync(path.join(dirPath, file)).isDirectory()) {
-              await sync(path.join(dirPath, file));
+              await refresh(path.join(dirPath, file));
             } else if (extname === '.prefab' || extname === '.asset' || extname === '.unity') {
               readMeta(path.join(dirPath, file));
             }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -43,7 +43,6 @@ export async function refreshUnityProject() {
   vscode.window.showInformationMessage('Start Refresh Unity Project');
   outputLog('Start Refresh Unity Project');
   await refresh(assetPath);
-  console.log(metaDatas);
   vscode.window.showInformationMessage('Finish Refresh Unity Project');
   outputLog('Finish Refresh Unity Project');
 }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -49,7 +49,7 @@ export async function refreshUnityProject() {
   outputLog('Finish Refresh Unity Project');
 }
 
-export function findFileReference() {
+export function findMetaReference() {
   const activeTextEditor = vscode.window.activeTextEditor;
   if (!activeTextEditor) {
     outputLog('Cannot find current active editor');

--- a/src/metaData.ts
+++ b/src/metaData.ts
@@ -1,0 +1,7 @@
+export class MetaData {
+    path: string;
+
+    constructor(path: string) {
+        this.path = path;
+    }
+}

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2,7 +2,6 @@ import fs = require('fs');
 
 export function getGuid(path: string) {
     var data = fs.readFileSync(path, { encoding: 'utf8' });
-    console.log(data);
     let regex = /guid: (.*)/;
     return data.match(regex)?.[1] ?? "";
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,7 +1,9 @@
-// guid:.\w+
+import fs = require('fs');
 
-export function getGuid(data: string) {
-    let regex = /guid: (.*),/;
+export function getGuid(path: string) {
+    var data = fs.readFileSync(path, { encoding: 'utf8' });
+    console.log(data);
+    let regex = /guid: (.*)/;
     return data.match(regex)?.[1] ?? "";
 }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -21,3 +21,15 @@ export function getGuids(data: string) {
     let regex = /guid: (.*),/g;
     return data.matchAll(regex) ?? [];
 }
+
+export function getLineNumbers(guid: string, path: string) {
+    var data = fs.readFileSync(path, { encoding: 'utf8' });
+    var lines: number[] = [];
+    const lineData = data.split(/\r?\n/);
+    for (let i = 0; i < lineData.length; i++) {
+        if (lineData[i].includes(guid)) {
+            lines.push(i);
+        }
+    }
+    return lines;
+}

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,7 +1,7 @@
 // guid:.\w+
 
 export function getGuid(data: string) {
-    let regex = /guid: (.*)/;
+    let regex = /guid: (.*),/;
     return data.match(regex)?.[1] ?? "";
 }
 
@@ -13,4 +13,9 @@ export function getProjectName(data: string) {
 export function getProjectVersion(data: string) {
     let regex = /m_EditorVersionWithRevision: (.*)/;
     return data.match(regex)?.[1] ?? "";
+};
+
+export function getGuids(data: string) {
+    let regex = /guid: (.*),/g;
+    return data.matchAll(regex) ?? [];
 }

--- a/src/vscode/command.ts
+++ b/src/vscode/command.ts
@@ -8,6 +8,7 @@ export function updateStatus<T>(name: string, value: T) {
 export function initialize(context: vscode.ExtensionContext) {
     registerCommand(context, 'clover.findMetaReference', () => findMetaReference());
 	registerCommand(context, 'clover.refreshUnityProject', () => refreshUnityProject());
+	registerCommand(context, 'clover.noReferenceMessage', () => vscode.window.showInformationMessage("No reference found"));
 }
 
 function registerCommand(context: vscode.ExtensionContext, command: string, callback: (...args: any[]) => any) {

--- a/src/vscode/command.ts
+++ b/src/vscode/command.ts
@@ -1,12 +1,12 @@
 import * as vscode from 'vscode';
-import { refreshUnityProject, findFileReference } from '../loader';
+import { refreshUnityProject, findMetaReference } from '../loader';
 
 export function updateStatus<T>(name: string, value: T) {
     vscode.commands.executeCommand('setContext', name, value);
 }
 
 export function initialize(context: vscode.ExtensionContext) {
-    registerCommand(context, 'clover.findFileReference', () => findFileReference());
+    registerCommand(context, 'clover.findMetaReference', () => findMetaReference());
 	registerCommand(context, 'clover.refreshUnityProject', () => refreshUnityProject());
 }
 


### PR DESCRIPTION
![image](https://github.com/novemberi/clover/assets/37071240/bdc82d9c-0a32-42b9-bae3-d550114b8275)

Now code lens meta reference is support reference count, and reference view.
Unfortunately, vscode reference view isn't support plain text on `.prefab`, `.unity`, `.asset` file extension.
I think this is the best way, now on.