### PR TITLE
Fix prefab prefab viewer

### DIFF
--- a/src/unityAssetViewer/unityAssetViewer.ts
+++ b/src/unityAssetViewer/unityAssetViewer.ts
@@ -72,7 +72,9 @@ class UnityAssetViewer {
                     </div>
 				</div>
                 <script>
-                    updateHierarchy(${JSON.stringify(transforms)});
+                    updateHierarchy(${JSON.stringify(transforms, (key, value) => 
+                            typeof(value) === 'bigint' ? value.toString() : value
+                            )});
                 </script>
             </script>
 			</body>


### PR DESCRIPTION
Reason:
Unity prefab fileID is big numbers.

Update yaml parser, and edit JSON.stringfy logics.

[parser update detail](https://github.com/novemberi/unity-yaml-parser/releases/tag/0.1.6)